### PR TITLE
Fix uid 1000 problems when building stemcells with virtualbox image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+
+## Prerequisites
+You need to install a few dependencies for the build to succeed. We include examples using Homebrew here. Replace with your package manager of choice.
+
+* Install [Chef-DK](https://downloads.chef.io/chef-dk/) to get berkshelf
+  ```
+  brew cask install chefdk
+  ```
+* Install packer
+  ```
+  brew cask install packer
+  ```
+* Download [OVF Tool](https://www.vmware.com/support/developer/ovf/)
+* Clone the repository and vendor the cookbooks
+  ```
+  cd bosh-stemcell
+  berks vendor cookbooks
+  ```
+
+## Create a stemcell builder machine
+```
+packer -var 'ovf_tool_path=<path to your OVF Tool download>' -var 'build_identifier=<some unique string identifier>' -var 'aws_access_key=<your aws access key>' -var 'aws_secret_key=<your aws secret key>' template.json
+```
+This command builds both boxes: AWS and virtualbox. If you want to build only one of these boxes, specify an additional argument `-only=<amazon-ebs|virtualbox-iso>`. Note that you can set the aws keys to random strings if you don't want to build an AWS box.

--- a/bosh-stemcell/Berksfile
+++ b/bosh-stemcell/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://supermarket.chef.io"
 
 cookbook 'ruby_build'
-cookbook 'rbenv', github: 'fnichol/chef-rbenv', tag: 'v0.7.2'
+cookbook 'rbenv', github: 'chef-rbenv/chef-rbenv', tag: "v0.7.3"

--- a/bosh-stemcell/Berksfile.lock
+++ b/bosh-stemcell/Berksfile.lock
@@ -1,13 +1,13 @@
 DEPENDENCIES
   rbenv
-    git: git://github.com/fnichol/chef-rbenv.git
-    revision: f2b53292e810dd2b43f6121f9958f5f29979dcb1
-    tag: v0.7.2
+    git: git://github.com/chef-rbenv/chef-rbenv.git
+    revision: 043b75c3b4c4b9b6218ee466cbfe532a3b79feb1
+    tag: v0.7.3
   ruby_build
 
 GRAPH
-  java (1.22.0)
-  rbenv (0.7.2)
+  java (1.31.0)
+  rbenv (0.7.3)
     java (> 1.4.0)
     ruby_build (>= 0.0.0)
   ruby_build (0.8.0)

--- a/bosh-stemcell/http/preseed.cfg
+++ b/bosh-stemcell/http/preseed.cfg
@@ -17,7 +17,7 @@ d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman/confirm_write_new_label boolean true
 d-i passwd/user-fullname string ubuntu
-d-i passwd/user-uid string 900
+d-i passwd/user-uid string 1000
 d-i passwd/user-password password c1oudc0w
 d-i passwd/user-password-again password c1oudc0w
 d-i passwd/username string ubuntu

--- a/bosh-stemcell/template.json
+++ b/bosh-stemcell/template.json
@@ -29,9 +29,9 @@
         },
         {
             "type": "virtualbox-iso",
-            "iso_checksum": "4d94f6111b8fe47da94396180ce499d8c0bb44f3",
+            "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
             "iso_checksum_type": "sha1",
-            "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04-server-amd64.iso",
+            "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
             "boot_wait": "10s",
             "boot_command": [
                 "<esc><wait>",

--- a/bosh-stemcell/template.json
+++ b/bosh-stemcell/template.json
@@ -29,9 +29,9 @@
         },
         {
             "type": "virtualbox-iso",
-            "iso_checksum": "3bfa6eac84d527380d0cc52db9092cde127f161e",
+            "iso_checksum": "0501c446929f713eb162ae2088d8dc8b6426224a",
             "iso_checksum_type": "sha1",
-            "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.2-server-amd64.iso",
+            "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.3-server-amd64.iso",
             "boot_wait": "10s",
             "boot_command": [
                 "<esc><wait>",


### PR DESCRIPTION
When building bosh stemcells with a virtualbox image created from these templates, a test fails, because the UID is 900 instead of an expected 1000. See bug https://github.com/cloudfoundry/bosh/issues/807 and the [corresponding test](https://github.com/cloudfoundry/bosh/blob/master/bosh-stemcell/lib/bosh/stemcell/stage_runner.rb#L15-L19).

Stemcells built using the AWS box don't have this problem, because the user creation process is different in this packer build for both builder types.

This PR fixes the UID and makes a few other necessary changes. In detail
- It documents the build process
- It updates the rbenv cookbook, because the currently used version is no longer maintained and [doesn't work with Chef >= 12.3](https://github.com/chef-rbenv/chef-rbenv/issues/110)
- It updates the used Ubuntu server image from 14.04 to 14.04.3, because the former version is no longer available
- It sets the UID to 100 for the virtualbox builder

Still to be done: Update the virtualbox image referenced in [bosh-stemcell](https://github.com/cloudfoundry/bosh/blob/master/bosh-stemcell/Vagrantfile#L13)
